### PR TITLE
feat: add theme and kernel toggles

### DIFF
--- a/repl/jupyter-lite.json
+++ b/repl/jupyter-lite.json
@@ -1,11 +1,19 @@
 {
     "jupyter-lite-schema-version": 0,
     "jupyter-config-data": {
+      // Set the default UI theme
+      "theme": "JupyterLab Light",
+      // Enable or disable specific kernels
+      "kernelOptions": {
+        "python": true,
+        "micropython": false
+      },
       "disabledExtensions": [
         "@jupyterlab/drawio-extension",
         "jupyterlab-kernel-spy",
         "jupyterlab-tour"
       ]
+      // Additional customizations (e.g., extra extensions or localization) can be added here
     }
   }
   


### PR DESCRIPTION
## Summary
- allow choosing default UI theme via `theme`
- add `kernelOptions` for enabling/disabling kernels
- document future customizations for extensions or localization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897aba23c048323b17e34ff6c3246ac