### PR TITLE
Add AI provider clients

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,10 @@ bqplot
 pandas
 numpy
 geopandas
+
+# AI provider clients
+openai
+google-generativeai
+anthropic
+groq
+python-dotenv


### PR DESCRIPTION
## Summary
- add AI provider client packages to requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897aba4c0348323b67a18ae364438a3