### PR TITLE
Add secondary school programming curriculum

### DIFF
--- a/content/courses/README.md
+++ b/content/courses/README.md
@@ -1,0 +1,28 @@
+# Secondary School Programming Curriculum
+
+Welcome to the DataDruid Labs learning track for secondary school students. This curriculum focuses on building strong Python fundamentals through hands-on projects and also introduces JavaScript and SQL basics.
+
+## Python Track
+Learn core concepts and build real applications:
+
+- [`number_guessing_game.ipynb`](python/number_guessing_game.ipynb) – classic high/low game.
+- [`mad_libs_story.ipynb`](python/mad_libs_story.ipynb) – create a silly story from user input.
+- [`magic_8_ball.ipynb`](python/magic_8_ball.ipynb) – fortune-telling toy simulation.
+- [`area_calculator.ipynb`](python/area_calculator.ipynb) – compute area for shapes.
+- [`todo_list.ipynb`](python/todo_list.ipynb) – manage tasks in a list.
+- [`quiz_program.ipynb`](python/quiz_program.ipynb) – ask questions and score answers.
+- [`text_adventure.ipynb`](python/text_adventure.ipynb) – mini interactive story.
+- [`data_analysis.ipynb`](python/data_analysis.ipynb) – explore data with pandas.
+- [`password_generator.ipynb`](python/password_generator.ipynb) – create secure passwords.
+
+## JavaScript Track
+Start experimenting with dynamic web programming:
+
+- [`click_counter.ipynb`](javascript/click_counter.ipynb) – interactive button updates on each click.
+
+## SQL Track
+Use SQL to query structured data:
+
+- [`basic_queries.ipynb`](sql/basic_queries.ipynb) – create tables and run simple queries with SQLite.
+
+Each notebook contains guided code cells and can be run directly in the browser. Students are encouraged to experiment, modify the examples, and document their learning.

--- a/content/courses/javascript/click_counter.ipynb
+++ b/content/courses/javascript/click_counter.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "95b63647",
+   "metadata": {},
+   "source": [
+    "# Click Counter\n",
+    "A simple interactive button that counts clicks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "602171a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "let count = 0;\n",
+    "const button = document.createElement('button');\n",
+    "button.textContent = 'Clicks: 0';\n",
+    "button.onclick = () => {\n",
+    "  count++;\n",
+    "  button.textContent = `Clicks: ${count}`;\n",
+    "};\n",
+    "document.body.appendChild(button);\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "JavaScript",
+   "language": "javascript",
+   "name": "javascript"
+  },
+  "language_info": {
+   "name": "javascript",
+   "version": "es2017"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/area_calculator.ipynb
+++ b/content/courses/python/area_calculator.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "880bed49",
+   "metadata": {},
+   "source": [
+    "# Area Calculator\n",
+    "Compute area of a circle or rectangle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c191280",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shape = input('Choose shape (circle or rectangle): ')\n",
+    "if shape == 'circle':\n",
+    "    r = float(input('Enter radius: '))\n",
+    "    area = 3.14159 * r * r\n",
+    "elif shape == 'rectangle':\n",
+    "    w = float(input('Enter width: '))\n",
+    "    h = float(input('Enter height: '))\n",
+    "    area = w * h\n",
+    "else:\n",
+    "    area = 0\n",
+    "print('Area:', area)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/data_analysis.ipynb
+++ b/content/courses/python/data_analysis.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "068fcd38",
+   "metadata": {},
+   "source": [
+    "# Simple Data Analysis\n",
+    "Use pandas to analyze a small dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4cdc8ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "data = {'name': ['A','B','C'], 'score': [85,92,78]}\n",
+    "df = pd.DataFrame(data)\n",
+    "print(df.describe())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/mad_libs_story.ipynb
+++ b/content/courses/python/mad_libs_story.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "67ecb285",
+   "metadata": {},
+   "source": [
+    "# Mad Libs Story Generator\n",
+    "Create a funny story from user-provided words."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a271c92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noun = input('Enter a noun: ')\n",
+    "verb = input('Enter a verb: ')\n",
+    "adj = input('Enter an adjective: ')\n",
+    "print(f'The {adj} {noun} loves to {verb} every day.')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/magic_8_ball.ipynb
+++ b/content/courses/python/magic_8_ball.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "09afb4cf",
+   "metadata": {},
+   "source": [
+    "# Magic 8 Ball\n",
+    "Ask a question and get a random answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccdf5981",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "responses = ['Yes', 'No', 'Maybe', 'Ask again later']\n",
+    "question = input('Ask the Magic 8 Ball a question: ')\n",
+    "print(random.choice(responses))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/number_guessing_game.ipynb
+++ b/content/courses/python/number_guessing_game.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ab79bdc1",
+   "metadata": {},
+   "source": [
+    "# Number Guessing Game\n",
+    "Try to guess the random number between 1 and 100."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9335eb04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "number = random.randint(1, 100)\n",
+    "while True:\n",
+    "    guess = int(input('Guess the number: '))\n",
+    "    if guess < number:\n",
+    "        print('Too low!')\n",
+    "    elif guess > number:\n",
+    "        print('Too high!')\n",
+    "    else:\n",
+    "        print('Correct!')\n",
+    "        break\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/password_generator.ipynb
+++ b/content/courses/python/password_generator.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a4b37c2b",
+   "metadata": {},
+   "source": [
+    "# Password Generator\n",
+    "Generate a random password."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa85e128",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random, string\n",
+    "length = int(input('Password length: '))\n",
+    "chars = string.ascii_letters + string.digits\n",
+    "password = ''.join(random.choice(chars) for _ in range(length))\n",
+    "print('Generated password:', password)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/quiz_program.ipynb
+++ b/content/courses/python/quiz_program.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f17a10",
+   "metadata": {},
+   "source": [
+    "# Quiz Program\n",
+    "Answer questions and get your score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdc5c32c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "questions = {'Capital of France?': 'Paris', '2 + 2?': '4'}\n",
+    "score = 0\n",
+    "for q, a in questions.items():\n",
+    "    if input(q + ' ').strip().lower() == a.lower():\n",
+    "        score += 1\n",
+    "print('Score:', score, '/', len(questions))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/text_adventure.ipynb
+++ b/content/courses/python/text_adventure.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2515c775",
+   "metadata": {},
+   "source": [
+    "# Text-Based Adventure Game\n",
+    "Make choices in a simple adventure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60e28adf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = input('Enter your name: ')\n",
+    "print('Welcome', name)\n",
+    "choice = input('You see a fork in the road. Left or Right? ')\n",
+    "if choice.lower() == 'left':\n",
+    "    print('You encounter a dragon. Game over.')\n",
+    "else:\n",
+    "    print('You find a treasure chest. You win!')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/python/todo_list.ipynb
+++ b/content/courses/python/todo_list.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "25e26f32",
+   "metadata": {},
+   "source": [
+    "# To-Do List\n",
+    "Manage tasks with a simple console to-do list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2f0ffcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "todo = []\n",
+    "while True:\n",
+    "    action = input('Add, Show, or Quit: ').lower()\n",
+    "    if action == 'add':\n",
+    "        item = input('Item: ')\n",
+    "        todo.append(item)\n",
+    "    elif action == 'show':\n",
+    "        for i, item in enumerate(todo, 1):\n",
+    "            print(i, item)\n",
+    "    elif action == 'quit':\n",
+    "        break\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/courses/sql/basic_queries.ipynb
+++ b/content/courses/sql/basic_queries.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "37ebb105",
+   "metadata": {},
+   "source": [
+    "# Basic SQL with sqlite3\n",
+    "Create a table and run a simple query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13f7b0bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import sqlite3\n",
+    "con = sqlite3.connect(':memory:')\n",
+    "cur = con.cursor()\n",
+    "cur.execute('CREATE TABLE students (name TEXT, score INTEGER)')\n",
+    "cur.executemany('INSERT INTO students VALUES (?,?)', [('Alice',90),('Bob',85),('Cara',92)])\n",
+    "con.commit()\n",
+    "for row in cur.execute('SELECT name, score FROM students WHERE score > 88'):\n",
+    "    print(row)\n",
+    "con.close()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Introduce structured curriculum for secondary school learners under `content/courses`
- Add Python track with multiple hands-on project notebooks
- Provide starter JavaScript and SQL notebooks for broader exposure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aecad545788323b340e930f31c1c52